### PR TITLE
default HashAlgorithm to RS256 to support MS Azure AD

### DIFF
--- a/src/JwksFeature.cs
+++ b/src/JwksFeature.cs
@@ -46,10 +46,8 @@ namespace ServiceStack.Jwks {
 
             if (JwtAuthProvider.RequireHashAlgorithm) {
                 // infer the algorithm if it is described by a key from the set
-                var algo = keySet.Keys.FirstOrDefault(x => !string.IsNullOrEmpty(x.Algorithm))? .Algorithm;
-                if (algo != null) {
-                    JwtAuthProvider.HashAlgorithm = algo;
-                }
+                var algo = keySet.Keys.FirstOrDefault(x => !string.IsNullOrEmpty(x.Algorithm))?.Algorithm;
+                JwtAuthProvider.HashAlgorithm = algo ?? "RS256";
             }
 
             var key = keySet.Keys.First();


### PR DESCRIPTION
Thanks so much for creating this project and nuget package! I did run into a situation with MS Azure AD where they do not return the "alg" key in the jwks response (apparently it is optional in the spec and everyone else includes it).

Would love to continue using this library if we could get the HashAlgorithm defaulted to "RS256". 

Sample response (https://<tenant.b2clogin.com>/<tenant>.onmicrosoft.com/<flow name>discovery/v2.0/keys): 
`{
  "keys": [
    {
      "kid": "redacted",
      "nbf": 1493763266,
      "use": "sig",
      "kty": "RSA",
      "e": "AQAB",
      "n": "redacted"
    }
  ]
}` 